### PR TITLE
Typo "I workshop" >> "Il workshop"

### DIFF
--- a/docs/pages/workshop.html
+++ b/docs/pages/workshop.html
@@ -36,7 +36,7 @@
             </div>
             <div class="content">
                 <div class="container">
-                    <p> I workshop si terrà <strong>sabato 13 gennaio</strong> presso il laboratorio
+                    <p> Il workshop si terrà <strong>sabato 13 gennaio</strong> presso il laboratorio
                         <strong>Makerspace</strong>, <strong>dalle 8 alle 12:35</strong>.
                         (vicino al bar).
                     </p>


### PR DESCRIPTION
Typo fix from "I workshop" to "Il workshop"